### PR TITLE
修复“公式”下拉菜单按钮与微信公众号页面的下拉菜单按钮显示逻辑不一致问题

### DIFF
--- a/mpMath/assets/js/content-script.js
+++ b/mpMath/assets/js/content-script.js
@@ -77,7 +77,19 @@ chrome.runtime.sendMessage({}, function (response) {
 
                 formulaMenu.appendChild(dropdownMenu);
                 $(formulaMenu).click(function () {
-                    $(dropdownMenu).css('display', '');
+                    $(dropdownMenu).css('display', 'none');
+                });
+
+                $(document).click(function(event) {
+                    // 检查点击的元素是否是formulaMenu
+                    if (!$(event.target).closest(formulaMenu).length) {
+                        // 如果不是，下拉菜单消失
+                        $(dropdownMenu).css('display', 'none');
+                    }
+                    else {
+                        // 如果是，下拉菜单显示
+                        $(dropdownMenu).css('display', 'block');
+                    }
                 });
 
                 $('#js_media_list')[0].appendChild(formulaMenu);


### PR DESCRIPTION
作者你好，我今天在写微信公众号时发现需要编写数学公式在文章之中，但是微信公众号并没有提供这个功能，于是我找到了你编写的这个插件，但是安装完之后发现显示在“音频”旁边的“公式”下来菜单按钮和“音频”下拉菜单的按钮消失逻辑不一致，就是当我点击了“公式”按钮之后我不想点击显示出来的下拉菜单内的选项，而是想很自然的点击其他地方时下拉菜单自然消失，但是却不行，而我去尝试了“音频”下拉菜单按钮则可以，本着应该与微信公众号页面的显示与消失逻辑一致的原则，我为这个插件添加了一段代码来实现这个逻辑。也进行了测试，解决了这个问题。