### PR TITLE
解决因微信公众平台编辑器更新而导致的新公式插入失败的问题（#11）。

### DIFF
--- a/mpMath/assets/js/mpm-inject.js
+++ b/mpMath/assets/js/mpm-inject.js
@@ -24,7 +24,15 @@ var readyStateCheckInterval = setInterval(function() {
                         editing.innerHTML = event.data.text.substring(beg, end);
                         editingMode = false; // 还原为非编辑模式
                     } else {
-                        window.UE.getEditor('js_editor').execCommand('insertHTML', '\xA0' + event.data.text + '\xA0');
+                        window.__MP_Editor_JSAPI__.invoke({
+                            apiName: 'mp_editor_insert_html',  
+                            apiParam: {
+                                html: '\xA0' + event.data.text + '\xA0',
+                                isSelect: false
+                            },
+                            sucCb: (res) => {console.log('设置成功', res)},  
+                            errCb: (err) => {console.log('设置失败', err)} 
+                        })
                     }
                 }
             }

--- a/mpMath/manifest.json
+++ b/mpMath/manifest.json
@@ -4,7 +4,7 @@
     "description": "微信公众号公式插件.",
     "permissions": ["storage", "declarativeContent", "activeTab", "scripting"],
     "background": {
-        "background.service_worker": "assets/js/background.js",
+        "service_worker": "assets/js/background.js",
         "type": "module"
     },
     "action": {


### PR DESCRIPTION
# 修改说明

我按照 Issue #11 中 @Jw-23 的建议修改了 `mpm.inject.js` 文件中的第27行代码。修改之后，我在 Microsoft Edge 上可以正常插入新公式了。

另外，我还修改了 `manifest.json` 文件中的一个参数名称 `background.service_worker`。按照 [MDN Web Docs: Browser extensions](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/background) 中的说明，`background` 的参数名称是 `service_worker`。

```
{
  "name": "Demo of service worker + event page",
  "version": "1",
  "manifest_version": 3,
  "background": {
    "scripts": ["background.js"],
    "service_worker": "background.js"
  }
}

```

# 现有问题

每次重新加载公众号文章编辑页面时，公式插件总是会产生下图中的错误。但这个错误好像不影响插件的使用。

![image](https://github.com/user-attachments/assets/5ab6db93-7161-41a5-ab5c-f0df056e8a62)
